### PR TITLE
Query Parameter Expectation Order

### DIFF
--- a/src/main/scala/com/netaporter/precanned/Expectations.scala
+++ b/src/main/scala/com/netaporter/precanned/Expectations.scala
@@ -2,7 +2,6 @@ package com.netaporter.precanned
 
 import spray.http.HttpMethods._
 import spray.http._
-import spray.http.Uri.Query
 
 trait Expectations {
   val get = method(GET)
@@ -37,7 +36,7 @@ trait Expectations {
     r.uri.toString.endsWith(s)
 
   def query(kvs: (String, String)*): Expect = r =>
-    r.uri.query.filter(kvs.contains) == Query(kvs: _*)
+    r.uri.query.filter(kvs.contains).toSet == kvs.toSet
 
   def header(hs: HttpHeader*): Expect = r =>
     r.headers.filter(hs.contains) == hs.toList

--- a/src/main/scala/com/netaporter/precanned/Expectations.scala
+++ b/src/main/scala/com/netaporter/precanned/Expectations.scala
@@ -1,6 +1,7 @@
 package com.netaporter.precanned
 
 import spray.http.HttpMethods._
+import spray.http.Uri.Query
 import spray.http._
 
 trait Expectations {
@@ -39,6 +40,9 @@ trait Expectations {
     val params = r.uri.query.toSet
     kvs forall params.contains
   }
+
+  def orderedQuery(kvs: (String, String)*): Expect = r =>
+    r.uri.query.filter(kvs.contains) == Query(kvs: _*)
 
   def header(hs: HttpHeader*): Expect = r =>
     r.headers.filter(hs.contains) == hs.toList

--- a/src/main/scala/com/netaporter/precanned/Expectations.scala
+++ b/src/main/scala/com/netaporter/precanned/Expectations.scala
@@ -35,8 +35,10 @@ trait Expectations {
   def uriEndsWith(s: String): Expect = r =>
     r.uri.toString.endsWith(s)
 
-  def query(kvs: (String, String)*): Expect = r =>
-    r.uri.query.filter(kvs.contains).toSet == kvs.toSet
+  def query(kvs: (String, String)*): Expect = r => {
+    val params = r.uri.query.toSet
+    kvs forall params.contains
+  }
 
   def header(hs: HttpHeader*): Expect = r =>
     r.headers.filter(hs.contains) == hs.toList

--- a/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
@@ -20,6 +20,16 @@ class BasicDslSpec
   after { animalApi.clearExpectations }
   override def afterAll() { system.shutdown() }
 
+  "query expectation" should "match in any order" in {
+    animalApi.expect(query("key1" -> "val1", "key2" -> "val2"))
+      .andRespondWith(resource("/responses/animals.json"))
+
+    val resF = pipeline(Get("http://127.0.0.1:8765?key2=val2&key1=val1"))
+    val res = Await.result(resF, dur)
+
+    res.entity.asString should equal("""[{"name": "rhino"}, {"name": "giraffe"}, {"name": "tiger"}]""")
+  }
+
   "path expectation" should "match path" in {
     animalApi.expect(path("/animals"))
       .andRespondWith(resource("/responses/animals.json"))


### PR DESCRIPTION
Hello, I propose this PR as a fix to allow query parameters to be in an arbitrary order (in respect to the expected URL).