### PR TITLE
Support Custom Interface Specification

### DIFF
--- a/src/main/scala/com/netaporter/precanned/dsl/basic.scala
+++ b/src/main/scala/com/netaporter/precanned/dsl/basic.scala
@@ -33,13 +33,11 @@ object basic extends Expectations with CannedResponses {
 
   case class Start(mock: ActorRef) extends MockDsl {
 
-    def bind(interface: String, port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) = {
+    def bind(port: Int, interface: String = "127.0.0.1")(implicit as: ActorSystem, t: Timeout = 5.seconds): BindInProgress = {
       val bindFuture = IO(Http) ? Http.Bind(mock, interface, port = port)
       BindInProgress(mock, bindFuture.mapTo[Http.Bound], t)
     }
 
-    def bind(port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) =
-      bind("127.0.0.1", port)
   }
 
   case class BindInProgress(mock: ActorRef, bind: Future[Http.Bound], t: Timeout) extends MockDsl {

--- a/src/main/scala/com/netaporter/precanned/dsl/basic.scala
+++ b/src/main/scala/com/netaporter/precanned/dsl/basic.scala
@@ -33,10 +33,13 @@ object basic extends Expectations with CannedResponses {
 
   case class Start(mock: ActorRef) extends MockDsl {
 
-    def bind(port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) = {
-      val bindFuture = IO(Http) ? Http.Bind(mock, "127.0.0.1", port = port)
+    def bind(interface: String, port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) = {
+      val bindFuture = IO(Http) ? Http.Bind(mock, interface, port = port)
       BindInProgress(mock, bindFuture.mapTo[Http.Bound], t)
     }
+
+    def bind(port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) =
+      bind("127.0.0.1", port)
   }
 
   case class BindInProgress(mock: ActorRef, bind: Future[Http.Bound], t: Timeout) extends MockDsl {

--- a/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
+++ b/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
@@ -42,13 +42,12 @@ object fancy extends Expectations with CannedResponses {
   }
 
   case class Start(mock: ActorRef) extends MockDsl {
-    def bind(interface: String, port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) = {
+
+    def bind(port: Int, interface: String = "127.0.0.1")(implicit as: ActorSystem, t: Timeout = 5.seconds): BindInProgress = {
       val bindFuture = IO(Http) ? Http.Bind(mock, interface, port = port)
       BindInProgress(mock, bindFuture.mapTo[Http.Bound], t)
     }
 
-    def bind(port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) =
-      bind("127.0.0.1", port)
   }
 
   case class BindInProgress(mock: ActorRef, bind: Future[Http.Bound], t: Timeout) extends MockDsl {

--- a/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
+++ b/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
@@ -42,10 +42,13 @@ object fancy extends Expectations with CannedResponses {
   }
 
   case class Start(mock: ActorRef) extends MockDsl {
-    def bind(port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) = {
-      val bindFuture = IO(Http) ? Http.Bind(mock, "127.0.0.1", port = port)
+    def bind(interface: String, port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) = {
+      val bindFuture = IO(Http) ? Http.Bind(mock, interface, port = port)
       BindInProgress(mock, bindFuture.mapTo[Http.Bound], t)
     }
+
+    def bind(port: Int)(implicit as: ActorSystem, t: Timeout = 5.seconds) =
+      bind("127.0.0.1", port)
   }
 
   case class BindInProgress(mock: ActorRef, bind: Future[Http.Bound], t: Timeout) extends MockDsl {


### PR DESCRIPTION
Hey, I propose with this PR to allow specification of a custom interface binding. With fallback to the default one.