### PR TITLE
Ability of binding to a random available port

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 ---
+dist: trusty # downgrade the dist to make oracle jdk 8 work
+
 language: scala
 script: "sbt ++$TRAVIS_SCALA_VERSION test"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 ---
-dist: trusty # downgrade the dist to make oracle jdk 8 work
+dist: bionic
 
 language: scala
 script: "sbt ++$TRAVIS_SCALA_VERSION test"
 
 jdk:
-  - oraclejdk8
+  - openjdk11
 
 scala:
-  - 2.11.12
-  - 2.12.10
+  - 2.12.11
+  - 2.13.3
 
 sudo: false # Enable new travis container-based infrastructure

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - oraclejdk8
 
 scala:
-  - 2.11.11
-  - 2.12.3
+  - 2.11.12
+  - 2.12.10
 
 sudo: false # Enable new travis container-based infrastructure

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
   - oraclejdk8
 
 scala:
-  - 2.10.5
-  - 2.11.7
+  - 2.11.11
+  - 2.12.3
 
 sudo: false # Enable new travis container-based infrastructure

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Introduction
 Pre-canned helps you to mock out the HTTP services your application depends on. This can be especially useful
 for your integration testing.
 
-For SBT add the dependency `"io.github.a-fistful-of-code" %% "pre-canned" % "0.1.0" % "test"`
+For SBT add the dependency `"io.github.a-fistful-of-code" %% "pre-canned" % "0.1.1" % "test"`
 
 DSLs
 ----

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@ Pre-canned
 ==========
 
 [![Build Status](https://travis-ci.org/a-fistful-of-code/pre-canned.svg?branch=master)](https://travis-ci.org/a-fistful-of-code/pre-canned)
-[![Maven Central](https://img.shields.io/maven-central/v/io.github.a-fistful-of-code/pre-canned_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.a-fistful-of-code/pre-canned_2.11)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.a-fistful-of-code/pre-canned_2.13.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.a-fistful-of-code/pre-canned_2.13)
 
 Mocking HTTP services on [Akka HTTP](http://doc.akka.io/docs/akka-http/current/scala/http)
 for integration testing.
 
 Port of [NET-A-PORTER/pre-canned](https://github.com/NET-A-PORTER/pre-canned)
 from [spray can](http://spray.io) to [Akka HTTP](http://doc.akka.io/docs/akka-http/current/scala/http),
-cross-compiled for Scala 2.11 and 2.12.
+cross-compiled for 2.12 and 2.13.
 
 Introduction
 ------------
@@ -25,7 +25,7 @@ DSLs
 Pre-canned currently comes in two flavours:
 
  * *[`basic`](#basic)* - Simple, but many parentheses
- * *[`fancy`](#fancy)* - Few parentheses, but quite wordy
+ * *[`fancy`](#fancy)* - Few parentheses, but quite wordy. Also requires to enable postfixOps on Scala 2.13
 
 Help make Pre-canned better and submit a new improved flavour via a PR, or ideas for one in an issue.
 
@@ -53,13 +53,14 @@ animalApi.expect(get, path("/animals"), query("name" -> "giraffe"))
 
 ```scala
 import com.netaporter.precanned.dsl.fancy._
+import scala.language.postfixOps
 
 val animalApi = httpServerMock(system).bind(8766).block
 
 animalApi expect
   get and path("/animals") and query("name" -> "giraffe") and
 respond using
-  resource("/responses/giraffe.json") end()
+  resource("/responses/giraffe.json") end
 ```
 
 ### Adding artificial latency
@@ -79,11 +80,12 @@ animalApi.expect(get, path("/animals"))
 
 ```scala
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 animalApi expect
   get and path("/animals") and
 respond using
-  resource("/responses/giraffe.json") and delay(5.seconds) end()
+  resource("/responses/giraffe.json") and delay(5.seconds) end
 ```
 
 ### Blocking until expectations have been added

--- a/README.md
+++ b/README.md
@@ -1,9 +1,15 @@
 Pre-canned
 ==========
 
-[![Build Status](https://travis-ci.org/NET-A-PORTER/pre-canned.svg?branch=0.0.5)](https://travis-ci.org/NET-A-PORTER/pre-canned)
+[![Build Status](https://travis-ci.org/a-fistful-of-code/pre-canned.svg?branch=master)](https://travis-ci.org/a-fistful-of-code/pre-canned)
+[![Maven Central](https://img.shields.io/maven-central/v/io.github.a-fistful-of-code/pre-canned_2.11.svg)](https://maven-badges.herokuapp.com/maven-central/io.github.a-fistful-of-code/pre-canned_2.11)
 
-Mocking HTTP services on [spray can](http://spray.io) for integration testing
+Mocking HTTP services on [Akka HTTP](http://doc.akka.io/docs/akka-http/current/scala/http)
+for integration testing.
+
+Port of [NET-A-PORTER/pre-canned](https://github.com/NET-A-PORTER/pre-canned)
+from [spray can](http://spray.io) to [Akka HTTP](http://doc.akka.io/docs/akka-http/current/scala/http),
+cross-compiled for Scala 2.11 and 2.12.
 
 Introduction
 ------------
@@ -11,7 +17,7 @@ Introduction
 Pre-canned helps you to mock out the HTTP services your application depends on. This can be especially useful
 for your integration testing.
 
-For SBT add the dependency `"com.netaporter" %% "pre-canned" % "0.0.8" % "test"`
+For SBT add the dependency `"io.github.a-fistful-of-code" %% "pre-canned" % "0.1.0" % "test"`
 
 DSLs
 ----
@@ -23,7 +29,11 @@ Pre-canned currently comes in two flavours:
 
 Help make Pre-canned better and submit a new improved flavour via a PR, or ideas for one in an issue.
 
-There are a basic set of [expectations](https://github.com/NET-A-PORTER/pre-canned/blob/master/src/main/scala/com/netaporter/precanned/Expectations.scala) and [canned responses](https://github.com/NET-A-PORTER/pre-canned/blob/master/src/main/scala/com/netaporter/precanned/CannedResponses.scala). Feel free to contribute more via a PR.
+There are a basic set of
+[expectations](https://github.com/a-fistful-of-code/pre-canned/blob/master/src/main/scala/com/netaporter/precanned/Expectations.scala)
+and
+[canned responses](https://github.com/a-fistful-of-code/pre-canned/blob/master/src/main/scala/com/netaporter/precanned/CannedResponses.scala).
+Feel free to contribute more via a PR.
 
 ### basic
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Introduction
 Pre-canned helps you to mock out the HTTP services your application depends on. This can be especially useful
 for your integration testing.
 
-For SBT add the dependency `"io.github.a-fistful-of-code" %% "pre-canned" % "0.1.1" % "test"`
+For SBT add the dependency `"io.github.a-fistful-of-code" %% "pre-canned" % "0.2.0" % "test"`
 
 DSLs
 ----

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,9 @@ name := "pre-canned"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
-val akkaVersion = "2.4.20"
-val akkaHttpVersion = "10.0.9"
-val scalatestVersion = "3.0.3"
+val akkaVersion = "2.5.27"
+val akkaHttpVersion = "10.1.11"
+val scalatestVersion = "3.1.0"
 
 libraryDependencies ++=
   "com.typesafe.akka" %% "akka-actor" % akkaVersion ::

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
-organization := "com.netaporter"
+organization := "io.github.a-fistful-of-code"
 
-version := "0.0.8"
+version := "0.1.0"
 
 val scala211Version = "2.11.11"
-val scala212Version = "2.12.2"
+val scala212Version = "2.12.3"
 
-scalaVersion := scala211Version
+scalaVersion := scala212Version
 
 crossScalaVersions := Seq(scala211Version, scala212Version)
 
@@ -13,12 +13,13 @@ name := "pre-canned"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
-val akkaVersion = "2.4.18"
-val akkaHttpVersion = "10.0.6"
+val akkaVersion = "2.4.20"
+val akkaHttpVersion = "10.0.9"
 val scalatestVersion = "3.0.3"
 
 libraryDependencies ++=
   "com.typesafe.akka" %% "akka-actor" % akkaVersion ::
+  "com.typesafe.akka" %% "akka-stream" % akkaVersion ::
   "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion ::
   Nil
 
@@ -38,7 +39,7 @@ publishTo <<= version { (v: String) =>
 }
 
 pomExtra := (
-  <url>https://github.com/net-a-porter/pre-canned</url>
+  <url>https://github.com/a-fistful-of-code/pre-canned</url>
     <licenses>
       <license>
         <name>Apache 2</name>
@@ -47,8 +48,8 @@ pomExtra := (
       </license>
     </licenses>
     <scm>
-      <url>git@github.com:net-a-porter/pre-canned.git</url>
-      <connection>scm:git@github.com:net-a-porter/pre-canned.git</connection>
+      <url>git@github.com:a-fistful-of-code/pre-canned.git</url>
+      <connection>scm:git@github.com:a-fistful-of-code/pre-canned.git</connection>
     </scm>
     <developers>
       <developer>

--- a/build.sbt
+++ b/build.sbt
@@ -2,27 +2,29 @@ organization := "com.netaporter"
 
 version := "0.0.8"
 
-scalaVersion := "2.11.5"
+val scala211Version = "2.11.11"
+val scala212Version = "2.12.2"
 
-crossScalaVersions := Seq(scalaVersion.value, "2.10.4")
+scalaVersion := scala211Version
+
+crossScalaVersions := Seq(scala211Version, scala212Version)
 
 name := "pre-canned"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
-val akka = "2.3.9"
-val spray = "1.3.1"
+val akkaVersion = "2.4.18"
+val akkaHttpVersion = "10.0.6"
+val scalatestVersion = "3.0.3"
 
 libraryDependencies ++=
-  "com.typesafe.akka" %% "akka-actor" % akka ::
-  "io.spray" %% "spray-can" % spray ::
-  "io.spray" %% "spray-http" % spray ::
+  "com.typesafe.akka" %% "akka-actor" % akkaVersion ::
+  "com.typesafe.akka" %% "akka-http-core" % akkaHttpVersion ::
   Nil
 
 libraryDependencies ++=
-  "io.spray" %% "spray-client" % spray % "test" ::
-  "com.typesafe.akka" %% "akka-testkit" % akka % "test" ::
-  "org.scalatest" %% "scalatest" % "2.2.4" % "test" ::
+  "com.typesafe.akka" %% "akka-testkit" % akkaVersion % "test" ::
+  "org.scalatest" %% "scalatest" % scalatestVersion % "test" ::
   Nil
 
 scalariformSettings

--- a/build.sbt
+++ b/build.sbt
@@ -1,19 +1,19 @@
 organization := "io.github.a-fistful-of-code"
 
-val scala211Version = "2.11.12"
-val scala212Version = "2.12.10"
+val scala212Version = "2.12.11"
+val scala213Version = "2.13.3"
 
-scalaVersion := scala212Version
+scalaVersion := scala213Version
 
-crossScalaVersions := Seq(scala211Version, scala212Version)
+crossScalaVersions := Seq(scala212Version, scala213Version)
 
 name := "pre-canned"
 
 scalacOptions := Seq("-unchecked", "-deprecation", "-encoding", "utf8")
 
-val akkaVersion = "2.5.27"
-val akkaHttpVersion = "10.1.11"
-val scalatestVersion = "3.1.0"
+val akkaVersion = "2.6.8"
+val akkaHttpVersion = "10.1.12"
+val scalatestVersion = "3.2.0"
 
 libraryDependencies ++=
   "com.typesafe.akka" %% "akka-actor" % akkaVersion ::

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 organization := "io.github.a-fistful-of-code"
 
-val scala211Version = "2.11.11"
-val scala212Version = "2.12.3"
+val scala211Version = "2.11.12"
+val scala212Version = "2.12.10"
 
 scalaVersion := scala212Version
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,5 @@
 organization := "io.github.a-fistful-of-code"
 
-version := "0.1.0"
-
 val scala211Version = "2.11.11"
 val scala212Version = "2.12.3"
 
@@ -28,33 +26,27 @@ libraryDependencies ++=
   "org.scalatest" %% "scalatest" % scalatestVersion % "test" ::
   Nil
 
-scalariformSettings
-
-publishTo <<= version { (v: String) =>
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT"))
-    Some("snapshots" at nexus + "content/repositories/snapshots")
+publishTo := Some(
+  if (isSnapshot.value)
+    Opts.resolver.sonatypeSnapshots
   else
-    Some("releases"  at nexus + "service/local/staging/deploy/maven2")
-}
+    Opts.resolver.sonatypeStaging
+)
 
-pomExtra := (
-  <url>https://github.com/a-fistful-of-code/pre-canned</url>
-    <licenses>
-      <license>
-        <name>Apache 2</name>
-        <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-        <distribution>repo</distribution>
-      </license>
-    </licenses>
-    <scm>
-      <url>git@github.com:a-fistful-of-code/pre-canned.git</url>
-      <connection>scm:git@github.com:a-fistful-of-code/pre-canned.git</connection>
-    </scm>
-    <developers>
-      <developer>
-        <id>theon</id>
-        <name>Ian Forsey</name>
-        <url>http://theon.github.io</url>
-      </developer>
-    </developers>)
+import ReleaseTransformations._
+
+releaseCrossBuild := true // true if you cross-build the project for multiple Scala versions
+releaseProcess := Seq[ReleaseStep](
+  checkSnapshotDependencies,
+  inquireVersions,
+  runClean,
+  runTest,
+  setReleaseVersion,
+  commitReleaseVersion,
+  tagRelease,
+  releaseStepCommand("publishSigned"),
+  setNextVersion,
+  commitNextVersion,
+  releaseStepCommand("sonatypeReleaseAll"),
+  pushChanges
+)

--- a/build.sbt
+++ b/build.sbt
@@ -44,9 +44,9 @@ releaseProcess := Seq[ReleaseStep](
   setReleaseVersion,
   commitReleaseVersion,
   tagRelease,
-  releaseStepCommand("publishSigned"),
+  ReleaseStep(releaseStepCommand("publishSigned"), enableCrossBuild = true),
   setNextVersion,
   commitNextVersion,
-  releaseStepCommand("sonatypeReleaseAll"),
+  ReleaseStep(releaseStepCommand("sonatypeReleaseAll"), enableCrossBuild = true),
   pushChanges
 )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.6
+sbt.version=1.3.13

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.3.6

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.1
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.3")
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.4")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.12")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.13")

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,4 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.2.1")
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.8.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "1.1")
+addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.6")

--- a/sonatype.sbt
+++ b/sonatype.sbt
@@ -1,0 +1,22 @@
+publishMavenStyle := true
+
+pomExtra :=
+  <url>https://github.com/a-fistful-of-code/pre-canned</url>
+    <licenses>
+      <license>
+        <name>Apache 2</name>
+        <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+        <distribution>repo</distribution>
+      </license>
+    </licenses>
+    <scm>
+      <url>git@github.com:a-fistful-of-code/pre-canned.git</url>
+      <connection>scm:git@github.com:a-fistful-of-code/pre-canned.git</connection>
+    </scm>
+    <developers>
+      <developer>
+        <id>theon</id>
+        <name>Ian Forsey</name>
+        <url>http://theon.github.io</url>
+      </developer>
+    </developers>

--- a/src/main/scala/com/netaporter/precanned/CannedResponses.scala
+++ b/src/main/scala/com/netaporter/precanned/CannedResponses.scala
@@ -1,6 +1,6 @@
 package com.netaporter.precanned
 
-import spray.http._
+import akka.http.scaladsl.model._
 import scala.concurrent.duration.FiniteDuration
 import scala.io.Source
 
@@ -14,14 +14,14 @@ trait CannedResponses {
   }
 
   def header(h: HttpHeader): Precanned = mapResponse { r =>
-    r.copy(headers = h :: r.headers)
+    r.copy(headers = h +: r.headers)
   }
 
   def contentType(c: ContentType): Precanned = mapResponse { r =>
-    r.mapEntity { e => HttpEntity(c, e.data) }
+    r.mapEntity { e => e.withContentType(c) }
   }
 
-  def entity(e: HttpEntity): Precanned = mapResponse { r =>
+  def entity(e: ResponseEntity): Precanned = mapResponse { r =>
     r.withEntity(e)
   }
 

--- a/src/main/scala/com/netaporter/precanned/HttpServerMock.scala
+++ b/src/main/scala/com/netaporter/precanned/HttpServerMock.scala
@@ -30,7 +30,8 @@ object HttpServerMock {
     requestToStrictDuration: FiniteDuration = 5.seconds,
     //you can't pre-can a delayed response with a delay larger than this timeout
     mockAskTimeout: Timeout = 1.minute)(req: HttpRequest)(
-      implicit ec: ExecutionContext, materializer: Materializer): Future[HttpResponse] = req
+    implicit
+    ec: ExecutionContext, materializer: Materializer): Future[HttpResponse] = req
     .toStrict(requestToStrictDuration)
     .flatMap(mockRef.ask(_)(timeout = mockAskTimeout)).mapTo[HttpResponse]
 

--- a/src/main/scala/com/netaporter/precanned/StrictHttpEntityOps.scala
+++ b/src/main/scala/com/netaporter/precanned/StrictHttpEntityOps.scala
@@ -1,0 +1,23 @@
+package com.netaporter.precanned
+
+import akka.http.scaladsl.model.{ ContentType, HttpEntity }
+
+/**
+ * Adds convenient methods to Akka HTTP HttpEntity using the assumption that all the instances of it are
+ * already strict.
+ */
+trait StrictHttpEntityOps {
+  implicit class RichHttpEntity(private val inner: HttpEntity) {
+    private def asStrict: HttpEntity.Strict = inner.asInstanceOf[HttpEntity.Strict]
+
+    def asString: String = {
+      val strict = asStrict
+      strict.contentType match {
+        case nonBinary: ContentType.NonBinary =>
+          strict.data.decodeString(nonBinary.charset.nioCharset())
+        case binary: ContentType.Binary =>
+          sys.error(s"unable to read as a string entity with a binary content type $binary")
+      }
+    }
+  }
+}

--- a/src/main/scala/com/netaporter/precanned/StrictHttpEntityOps.scala
+++ b/src/main/scala/com/netaporter/precanned/StrictHttpEntityOps.scala
@@ -15,6 +15,8 @@ trait StrictHttpEntityOps {
       strict.contentType match {
         case nonBinary: ContentType.NonBinary =>
           strict.data.decodeString(nonBinary.charset.nioCharset())
+        case _: ContentType.WithMissingCharset =>
+          strict.data.decodeString("UTF-8")
         case binary: ContentType.Binary =>
           sys.error(s"unable to read as a string entity with a binary content type $binary")
       }

--- a/src/main/scala/com/netaporter/precanned/dsl/basic.scala
+++ b/src/main/scala/com/netaporter/precanned/dsl/basic.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{ Await, Future }
 object basic extends Expectations with CannedResponses {
 
   def httpServerMock(af: ActorRefFactory): Start = {
-    val actor = af.actorOf(Props[HttpServerMock])
+    val actor = af.actorOf(Props[HttpServerMock]())
     Start(actor)
   }
 

--- a/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
+++ b/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
@@ -54,7 +54,7 @@ object fancy extends Expectations with CannedResponses {
 
   case class Start(mock: ActorRef) extends MockDsl {
 
-    def bind(port: Int, interface: String = "127.0.0.1")(implicit as: ActorSystem, t: Timeout = 5.seconds): BindInProgress = {
+    def bind(port: Int = 0, interface: String = "127.0.0.1")(implicit as: ActorSystem, t: Timeout = 5.seconds): BindInProgress = {
       val bindFuture = IO(Http) ? Http.Bind(mock, interface, port = port)
       BindInProgress(mock, bindFuture.mapTo[Http.Bound], t)
     }
@@ -63,12 +63,12 @@ object fancy extends Expectations with CannedResponses {
 
   case class BindInProgress(mock: ActorRef, bind: Future[Http.Bound], t: Timeout) extends MockDsl {
     def block = {
-      Await.result(bind, t.duration)
-      BoundComplete(mock)
+      val bound = Await.result(bind, t.duration)
+      BoundComplete(mock, bound)
     }
   }
 
-  case class BoundComplete(mock: ActorRef) extends MockDsl
+  case class BoundComplete(mock: ActorRef, bound: Http.Bound) extends MockDsl
 
   class RespondWord
   val respond = new RespondWord

--- a/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
+++ b/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
@@ -1,11 +1,11 @@
 package com.netaporter.precanned.dsl
 
-import akka.actor.{ ActorSystem, ActorRef, Props, ActorRefFactory }
+import akka.actor.{ ActorRef, ActorRefFactory, ActorSystem, Props }
+import akka.http.scaladsl.Http
 import com.netaporter.precanned._
-import akka.io.IO
-import spray.can.Http
 import com.netaporter.precanned.HttpServerMock._
 import akka.util.Timeout
+
 import scala.concurrent.{ Await, Future }
 import scala.concurrent.duration._
 import akka.pattern.ask
@@ -54,21 +54,22 @@ object fancy extends Expectations with CannedResponses {
 
   case class Start(mock: ActorRef) extends MockDsl {
 
-    def bind(port: Int = 0, interface: String = "127.0.0.1")(implicit as: ActorSystem, t: Timeout = 5.seconds): BindInProgress = {
-      val bindFuture = IO(Http) ? Http.Bind(mock, interface, port = port)
-      BindInProgress(mock, bindFuture.mapTo[Http.Bound], t)
+    def bind(
+      port: Int = 0, interface: String = "127.0.0.1")(implicit as: ActorSystem, t: Timeout = 5.seconds): BindInProgress = {
+      val bindFuture = HttpServerMock.startServer(mock, port, interface)
+      BindInProgress(mock, bindFuture, t)
     }
 
   }
 
-  case class BindInProgress(mock: ActorRef, bind: Future[Http.Bound], t: Timeout) extends MockDsl {
+  case class BindInProgress(mock: ActorRef, bind: Future[Http.ServerBinding], t: Timeout) extends MockDsl {
     def block = {
       val bound = Await.result(bind, t.duration)
       BoundComplete(mock, bound)
     }
   }
 
-  case class BoundComplete(mock: ActorRef, bound: Http.Bound) extends MockDsl
+  case class BoundComplete(mock: ActorRef, binding: Http.ServerBinding) extends MockDsl
 
   class RespondWord
   val respond = new RespondWord

--- a/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
+++ b/src/main/scala/com/netaporter/precanned/dsl/fancy.scala
@@ -13,7 +13,7 @@ import akka.pattern.ask
 object fancy extends Expectations with CannedResponses {
 
   def httpServerMock(implicit af: ActorRefFactory) = {
-    val actor = af.actorOf(Props[HttpServerMock])
+    val actor = af.actorOf(Props[HttpServerMock]())
     Start(actor)
   }
 
@@ -41,7 +41,9 @@ object fancy extends Expectations with CannedResponses {
 
       def and(also: Precanned) = copy(response = response andThen also)
 
-      def end(blockUpTo: FiniteDuration = 3.seconds): Option[PrecannedResponseAdded.type] = {
+      def end: Option[PrecannedResponseAdded.type] = end(3.seconds)
+
+      def end(blockUpTo: FiniteDuration): Option[PrecannedResponseAdded.type] = {
         val expectInProgress = mock.ask(ExpectAndRespondWith(expect, response(PrecannedResponse.empty)))(blockUpTo)
         if (blockUpTo > Duration.Zero) {
           Some(Await.result(expectInProgress.mapTo[PrecannedResponseAdded.type], blockUpTo))

--- a/src/main/scala/com/netaporter/precanned/package.scala
+++ b/src/main/scala/com/netaporter/precanned/package.scala
@@ -1,7 +1,7 @@
 package com.netaporter
 
+import akka.http.scaladsl.model.HttpRequest
 import com.netaporter.precanned.HttpServerMock.PrecannedResponse
-import spray.http.HttpRequest
 
 package object precanned {
   type Expect = HttpRequest => Boolean

--- a/src/test/scala/com/netaporter/precanned/BaseSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/BaseSpec.scala
@@ -3,17 +3,17 @@ package com.netaporter.precanned
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
-import akka.stream.ActorMaterializer
+import akka.stream.{ ActorMaterializer, Materializer }
 
 import scala.concurrent.duration._
-import scala.concurrent.Future
+import scala.concurrent.{ ExecutionContext, Future }
 
 trait BaseSpec {
-  implicit val system = ActorSystem()
-  implicit val ec = system.dispatcher
-  implicit val materializer = ActorMaterializer()
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val ec: ExecutionContext = system.dispatcher
+  implicit val materializer: Materializer = ActorMaterializer()
 
-  val dur = 5.seconds
+  val dur: FiniteDuration = 5.seconds
 
   val pipeline: HttpRequest => Future[HttpResponse] = req =>
     Http().singleRequest(req).flatMap(_.toStrict(dur))

--- a/src/test/scala/com/netaporter/precanned/BaseSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/BaseSpec.scala
@@ -3,7 +3,6 @@ package com.netaporter.precanned
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
-import akka.stream.{ ActorMaterializer, Materializer }
 
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
@@ -11,7 +10,6 @@ import scala.concurrent.{ ExecutionContext, Future }
 trait BaseSpec {
   implicit val system: ActorSystem = ActorSystem()
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val materializer: Materializer = ActorMaterializer()
 
   val dur: FiniteDuration = 5.seconds
 

--- a/src/test/scala/com/netaporter/precanned/BaseSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/BaseSpec.scala
@@ -1,17 +1,25 @@
 package com.netaporter.precanned
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model._
+import akka.stream.ActorMaterializer
+
 import scala.concurrent.duration._
 import scala.concurrent.Future
-import spray.client.pipelining._
-import spray.http.HttpRequest
-import spray.http.HttpResponse
 
 trait BaseSpec {
   implicit val system = ActorSystem()
-  implicit def ec = system.dispatcher
+  implicit val ec = system.dispatcher
+  implicit val materializer = ActorMaterializer()
 
   val dur = 5.seconds
 
-  val pipeline: HttpRequest => Future[HttpResponse] = sendReceive
+  val pipeline: HttpRequest => Future[HttpResponse] = req =>
+    Http().singleRequest(req).flatMap(_.toStrict(dur))
+
+  def Get(urlStr: String): HttpRequest = HttpRequest(method = HttpMethods.GET, uri = Uri(urlStr))
+
+  def Post(urlStr: String, body: String = ""): HttpRequest =
+    HttpRequest(method = HttpMethods.POST, uri = Uri(urlStr), entity = HttpEntity(body))
 }

--- a/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
@@ -10,12 +10,12 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class BasicDslSpec
-    extends FlatSpecLike
-    with Matchers
-    with BeforeAndAfter
-    with BeforeAndAfterAll
-    with OptionValues
-    with BaseSpec {
+  extends FlatSpecLike
+  with Matchers
+  with BeforeAndAfter
+  with BeforeAndAfterAll
+  with OptionValues
+  with BaseSpec {
 
   val port = 8765
   val animalApi = httpServerMock(system).bind(8765).block

--- a/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
@@ -130,4 +130,15 @@ class BasicDslSpec
     val blocked = animalApi.expect(get, path("/animals")).andRespondWith(status(200), delay(5.seconds)).blockFor(3.seconds)
     blocked should equal(PrecannedResponseAdded)
   }
+
+  "server mock" should "be bound to some available port" in {
+    val availablePortApi = httpServerMock(system).bind().block
+    val availablePort = availablePortApi.bound.localAddress.getPort
+    availablePortApi.expect(get, path("/status")).andRespondWith(entity("OK")).blockFor(3.seconds)
+
+    val resF = pipeline(Get(s"http://127.0.0.1:$availablePort/status"))
+    val res = Await.result(resF, dur)
+
+    res.entity.asString should equal("OK")
+  }
 }

--- a/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
@@ -3,14 +3,16 @@ package com.netaporter.precanned
 import akka.http.scaladsl.model.{ HttpEntity, StatusCodes }
 import StatusCodes._
 import com.netaporter.precanned.HttpServerMock.PrecannedResponseAdded
-import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, FlatSpecLike, Matchers, OptionValues }
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, OptionValues }
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import dsl.basic._
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class BasicDslSpec
-  extends FlatSpecLike
+  extends AnyFlatSpecLike
   with Matchers
   with BeforeAndAfter
   with BeforeAndAfterAll

--- a/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/BasicDslSpec.scala
@@ -23,7 +23,7 @@ class BasicDslSpec
   val animalApi: BoundComplete = httpServerMock(system).bind(8765).block
 
   after { animalApi.clearExpectations() }
-  override def afterAll() {
+  override def afterAll(): Unit = {
     Await.result(system.terminate(), Duration.Inf)
   }
 

--- a/src/test/scala/com/netaporter/precanned/FancyDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/FancyDslSpec.scala
@@ -10,11 +10,11 @@ import akka.http.scaladsl.model.ContentTypes._
 import scala.concurrent.duration._
 
 class FancyDslSpec
-    extends FlatSpecLike
-    with Matchers
-    with BeforeAndAfter
-    with BeforeAndAfterAll
-    with BaseSpec {
+  extends FlatSpecLike
+  with Matchers
+  with BeforeAndAfter
+  with BeforeAndAfterAll
+  with BaseSpec {
 
   // format: OFF
 

--- a/src/test/scala/com/netaporter/precanned/FancyDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/FancyDslSpec.scala
@@ -1,5 +1,7 @@
 package com.netaporter.precanned
 
+import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.ContentTypes._
 import com.netaporter.precanned.HttpServerMock.PrecannedResponseAdded
 import com.netaporter.precanned.dsl.fancy._
 import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll }
@@ -8,10 +10,8 @@ import org.scalatest.matchers.should.Matchers
 import akka.http.scaladsl.model.headers._
 
 import scala.concurrent.Await
-import akka.http.scaladsl.model.StatusCodes._
-import akka.http.scaladsl.model.ContentTypes._
-
 import scala.concurrent.duration._
+import scala.language.postfixOps
 
 class FancyDslSpec
   extends AnyFlatSpecLike
@@ -26,12 +26,13 @@ class FancyDslSpec
   val animalApi: BoundComplete = httpServerMock(system).bind(port).block
 
   after { animalApi.clearExpectations() }
-  override def afterAll() {
+  override def afterAll(): Unit = {
     Await.result(system.terminate(), Duration.Inf)
   }
 
   "query expectation" should "match in any order" in {
-    animalApi expect query ("key1" -> "val1", "key2" -> "val2") and respond using resource("/responses/animals.json") end()
+    animalApi expect query ("key1" -> "val1", "key2" -> "val2") and respond using
+      resource("/responses/animals.json") end
 
     val resF = pipeline(Get(s"http://127.0.0.1:$port?key2=val2&key1=val1"))
     val res = Await.result(resF, dur)
@@ -40,7 +41,8 @@ class FancyDslSpec
   }
 
   "path expectation" should "match path" in {
-    animalApi expect path("/animals") and respond using resource("/responses/animals.json") end()
+    animalApi expect path("/animals") and respond using
+      resource("/responses/animals.json") end
 
     val resF = pipeline(Get(s"http://127.0.0.1:$port/animals"))
     val res = Await.result(resF, dur)
@@ -49,7 +51,8 @@ class FancyDslSpec
   }
 
   "contentType CannedResponse" should "set Content-Type header" in {
-    animalApi expect path("/animals") and respond using resource("/responses/animals.json") and contentType(`application/json`) end()
+    animalApi expect path("/animals") and respond using
+      resource("/responses/animals.json") and contentType(`application/json`) end
 
     val resF = pipeline(Get(s"http://127.0.0.1:$port/animals"))
     val res = Await.result(resF, dur)
@@ -61,7 +64,7 @@ class FancyDslSpec
     animalApi expect
       get and path("/animals") and query("name" -> "giraffe") and
     respond using
-      resource("/responses/giraffe.json") end()
+      resource("/responses/giraffe.json") end
 
     val resF = pipeline(Get(s"http://127.0.0.1:$port/animals?name=giraffe"))
     val res = Await.result(resF, dur)
@@ -70,7 +73,8 @@ class FancyDslSpec
   }
 
   "earlier expectations" should "take precedence" in {
-    animalApi expect path("/animals") and respond using resource("/responses/animals.json") end()
+    animalApi expect path("/animals") and respond using
+      resource("/responses/animals.json") end
 
     animalApi expect
       get and query("name" -> "giraffe") and
@@ -84,7 +88,8 @@ class FancyDslSpec
   }
 
   "unmatched requests" should "return 404" in {
-    animalApi expect path("/animals") and respond using resource("/responses/animals.json") end()
+    animalApi expect path("/animals") and respond using
+      resource("/responses/animals.json") end
 
     val resF = pipeline(Get(s"http://127.0.0.1:8766/hotdogs"))
     val res = Await.result(resF, dur)
@@ -112,7 +117,7 @@ class FancyDslSpec
       animalApi expect
         get and path("/animals") and
       respond using
-        status(200) and delay(5.seconds) end()
+        status(200) and delay(5.seconds) end
 
     blocked should equal(Some(PrecannedResponseAdded))
   }
@@ -130,7 +135,7 @@ class FancyDslSpec
   "server mock" should "be bound to some available port" in {
     val availablePortApi = httpServerMock(system).bind().block
     val availablePort = availablePortApi.binding.localAddress.getPort
-    availablePortApi expect get and path("/status") and respond using entity("OK") end()
+    availablePortApi expect get and path("/status") and respond using entity("OK") end
 
     val resF = pipeline(Get(s"http://127.0.0.1:$availablePort/status"))
     val res = Await.result(resF, dur)

--- a/src/test/scala/com/netaporter/precanned/FancyDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/FancyDslSpec.scala
@@ -19,7 +19,7 @@ class FancyDslSpec
   // format: OFF
 
   val port = 8766
-  val animalApi = httpServerMock(system).bind(port).block
+  val animalApi: BoundComplete = httpServerMock(system).bind(port).block
 
   after { animalApi.clearExpectations() }
   override def afterAll() {

--- a/src/test/scala/com/netaporter/precanned/FancyDslSpec.scala
+++ b/src/test/scala/com/netaporter/precanned/FancyDslSpec.scala
@@ -2,15 +2,19 @@ package com.netaporter.precanned
 
 import com.netaporter.precanned.HttpServerMock.PrecannedResponseAdded
 import com.netaporter.precanned.dsl.fancy._
-import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll, FlatSpecLike, Matchers }
+import org.scalatest.{ BeforeAndAfter, BeforeAndAfterAll }
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import akka.http.scaladsl.model.headers._
+
 import scala.concurrent.Await
 import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.ContentTypes._
+
 import scala.concurrent.duration._
 
 class FancyDslSpec
-  extends FlatSpecLike
+  extends AnyFlatSpecLike
   with Matchers
   with BeforeAndAfter
   with BeforeAndAfterAll

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1-SNAPSHOT"
+version in ThisBuild := "0.1.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.2"
+version in ThisBuild := "0.1.3-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0-SNAPSHOT"
+version in ThisBuild := "0.1.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.1"
+version in ThisBuild := "0.1.2-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0"
+version in ThisBuild := "0.2.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.0"
+version in ThisBuild := "0.1.1-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild := "0.1.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.2-SNAPSHOT"
+version in ThisBuild := "0.1.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.1.3-SNAPSHOT"
+version in ThisBuild := "0.2.0"


### PR DESCRIPTION
This changes allow the server mock to be bound to some available port, manually specifying of the port is not required from now on.